### PR TITLE
migrate to use .md as the extension

### DIFF
--- a/sphinxcontrib/rst2myst/builders/myst.py
+++ b/sphinxcontrib/rst2myst/builders/myst.py
@@ -26,8 +26,8 @@ logger = logging.getLogger(__name__)
 class MystBuilder(Builder):
 
     name = 'myst'
-    format = 'myst'
-    out_suffix = ".myst"
+    format = 'markdown(myst)'
+    out_suffix = ".md"
     epilog = __('The myst files are in %(outdir)s.')
 
     allow_parallel = True

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,7 +25,7 @@ def test_basic(
     #Note: pytest needs to run twice to initialise fixtures
 
     get_sphinx_app_doctree(app, docname="test", regress=True)
-    get_sphinx_app_output(app, files=["index.myst", "test.myst"], regress=True)
+    get_sphinx_app_output(app, files=["index.md", "test.md"], regress=True)
 
 @pytest.mark.sphinx(
     buildername="myst", srcdir=os.path.join(SOURCE_DIR, "docutils"), freshenv=True
@@ -46,4 +46,4 @@ def test_docutils(
     #Note: pytest needs to run twice to initialise fixtures
 
     get_sphinx_app_doctree(app, docname="elements", regress=True)
-    get_sphinx_app_output(app, files=["index.myst", "elements.myst", "directives.myst", "roles.myst"], regress=True)
+    get_sphinx_app_output(app, files=["index.md", "elements.md", "directives.md", "roles.md"], regress=True)

--- a/tests/test_build/test_basic.myst
+++ b/tests/test_build/test_basic.myst
@@ -1,6 +1,6 @@
-----------
-index.myst
-----------
+--------
+index.md
+--------
 
 # Basic Test
 
@@ -10,9 +10,9 @@ index.myst
 This is the index page
 
 
----------
-test.myst
----------
+-------
+test.md
+-------
 
 # Testing Document
 

--- a/tests/test_build/test_docutils.myst
+++ b/tests/test_build/test_docutils.myst
@@ -1,6 +1,6 @@
-----------
-index.myst
-----------
+--------
+index.md
+--------
 
 # Docutils Tests
 
@@ -36,9 +36,9 @@ index.myst
     * [math](roles.myst#math)
 
 
--------------
-elements.myst
--------------
+-----------
+elements.md
+-----------
 
 # Elements
 
@@ -121,9 +121,9 @@ The enumerated list from docutils
 1. Item 2.
 
 
----------------
-directives.myst
----------------
+-------------
+directives.md
+-------------
 
 # Directives
 
@@ -284,9 +284,9 @@ This is a warning admonition
 ```
 
 
-----------
-roles.myst
-----------
+--------
+roles.md
+--------
 
 # Roles
 


### PR DESCRIPTION
from `.myst` to `.md` to take advantage of automatic highlighters for `markdown` in editors