### PR TITLE
[toctree] add work on supporting toctree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__
 *.pyc
 .DS_Store
 .vscode/
+
+tests/source/snippet/_build

--- a/sphinxcontrib/rst2myst/__init__.py
+++ b/sphinxcontrib/rst2myst/__init__.py
@@ -3,14 +3,12 @@ from typing import Any, Dict, Generator, List, Iterable, Optional, Set, Tuple, U
 from sphinx.application import Sphinx
 
 from .builders import MystBuilder
+from .transform import InterceptAST
 
 def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_builder(MystBuilder)
 
-    # app.add_config_value('text_sectionchars', '*=-~"+`', 'env')
-    # app.add_config_value('text_newlines', 'unix', 'env')
-    # app.add_config_value('text_add_secnumbers', True, 'env')
-    # app.add_config_value('text_secnumber_suffix', '. ', 'env')
+    app.add_transform(InterceptAST)
 
     return {
         'version': 'builtin',

--- a/sphinxcontrib/rst2myst/transform/__init__.py
+++ b/sphinxcontrib/rst2myst/transform/__init__.py
@@ -1,0 +1,21 @@
+"""
+Transform to Intercept Sphinx AST before transforms/post-transforms
+"""
+
+from docutils import nodes
+from sphinx.transforms import SphinxTransform
+from sphinx import addnodes
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+def intercept_ast(config, document, tags):
+    document.document_pretransforms = document.deepcopy()
+
+class InterceptAST(SphinxTransform):
+
+    default_priority = 1
+
+    def apply(self):
+        intercept_ast(self.config, self.document, self.app.builder.tags)
+

--- a/sphinxcontrib/rst2myst/writers/myst.py
+++ b/sphinxcontrib/rst2myst/writers/myst.py
@@ -55,8 +55,11 @@ class MystSyntax(MarkdownSyntax):
 
     # - Syntax Methods - #
 
-    def visit_directive(self, type):
-        return "```{" + "{}".format(type) + "}"
+    def visit_directive(self, type, options=None):
+        if options:
+            return "```{" + "{}".format(type) + "}" + "\n{}".format("\n".join(options))
+        else:
+            return "```{" + "{}".format(type) + "}"
 
     def depart_directive(self):
         return "```"

--- a/sphinxcontrib/rst2myst/writers/translator.py
+++ b/sphinxcontrib/rst2myst/writers/translator.py
@@ -1328,13 +1328,10 @@ class MystTranslator(SphinxTranslator):
             if node.attributes["hidden"]:
                 options['hidden'] = ''
         if node.hasattr("numbered"):
-            if node.attributes['numbered'] == 0:   #top level default value
+            if node.attributes['numbered'] == 999:   #top level default value
                 options['numbered'] = ''
-            else:
-                options['numbered'] = node.attributes['numbered']
         if node.hasattr("caption"):
-            if node.attributes['caption'] != 'Contents:':   #skip default value
-                options['caption'] = node.attributes['caption']
+            options['caption'] = node.attributes['caption']
         #TODO: implement :name: option
         if node.hasattr('titlesonly'):
             if node.attributes['titlesonly']:
@@ -1348,6 +1345,9 @@ class MystTranslator(SphinxTranslator):
         if node.hasattr('includehidden'):
             if node.attributes['includehidden']:
                 options['includehidden'] = ''
+        if node.hasattr('maxdepth'):
+            if type(node.attributes['maxdepth']) is int:
+                options['maxdepth'] = node.attributes['maxdepth']
         return listing, options
 
     def depart_toctree(self, node):

--- a/sphinxcontrib/rst2myst/writers/writer.py
+++ b/sphinxcontrib/rst2myst/writers/writer.py
@@ -15,6 +15,9 @@ class MystWriter(writers.Writer):
         self.builder = builder
 
     def translate(self) -> None:
+        reporter = self.document.reporter                            #save current reporter
+        self.document = self.document.document_pretransforms         #pass pre-transforms document to writer
+        self.document.reporter = reporter
         visitor = self.builder.create_translator(self.document, self.builder)
         self.document.walkabout(visitor)
         self.output = cast(MystTranslator, visitor).body

--- a/tests/test_build/test_basic.myst
+++ b/tests/test_build/test_basic.myst
@@ -4,8 +4,14 @@ index.md
 
 # Basic Test
 
+```{toctree}
+---
+caption: Contents:
+maxdepth: 2
+---
 
-* [Testing Document](test.myst)
+test
+```
 
 This is the index page
 

--- a/tests/test_build/test_docutils.myst
+++ b/tests/test_build/test_docutils.myst
@@ -4,36 +4,16 @@ index.md
 
 # Docutils Tests
 
+```{toctree}
+---
+caption: Contents:
+maxdepth: 2
+---
 
-* [Elements](elements.myst)
-    * [Text](elements.myst#text)
-    * [block_quote](elements.myst#block-quote)
-    * [bullet_list](elements.myst#bullet-list)
-    * [definition_list](elements.myst#definition-list)
-    * [docinfo](elements.myst#docinfo)
-    * [emphasis](elements.myst#emphasis)
-    * [enumerated_list](elements.myst#enumerated-list)
-* [Directives](directives.myst)
-    * [admonition](directives.myst#admonition)
-    * [attention](directives.myst#attention)
-    * [caution](directives.myst#caution)
-    * [danger](directives.myst#danger)
-    * [epigraph](directives.myst#epigraph)
-    * [figure](directives.myst#figure)
-    * [highlights](directives.myst#highlights)
-    * [index](directives.myst#index)
-    * [The execution context](directives.myst#the-execution-context)
-    * [pull-quote](directives.myst#pull-quote)
-    * [error](directives.myst#error)
-    * [hint](directives.myst#hint)
-    * [important](directives.myst#important)
-    * [math](directives.myst#math)
-    * [note](directives.myst#note)
-    * [tip](directives.myst#tip)
-    * [warning](directives.myst#warning)
-* [Roles](roles.myst)
-    * [index](roles.myst#index)
-    * [math](roles.myst#math)
+elements
+directives
+roles
+```
 
 
 -----------
@@ -101,7 +81,7 @@ This tests `definition`, `definition_list` and
 See docinfo elements at the top of this document
 just underneath the first title.
 
-They don’t appear to be transformed by sphinx/docutils
+They don't appear to be transformed by sphinx/docutils
 to be docinfo elements.
 
 [https://github.com/mmcky/sphinxcontrib-rst2myst/issues/19](https://github.com/mmcky/sphinxcontrib-rst2myst/issues/19)
@@ -192,7 +172,7 @@ single: python
 single: programming
 ```
 
-A point in the text you’d like to reference something
+A point in the text you'd like to reference something
 about python
 
 ```{{index}}
@@ -201,7 +181,7 @@ single: programming
 :name: reference-id
 ```
 
-A point in the text you’d like to reference something
+A point in the text you'd like to reference something
 about python
 
 ```{{index}}


### PR DESCRIPTION
This PR adds support for writing `toctree` directives provided by sphinx. 

As part of this PR a transform is added to save the `document` prior to `transforms` and `post_transforms`. This document has then passed to the translator which enables access to `toctree` nodes. However we will have to revisit other methods given we now have more direct access to the underlying RST. 