### PR TITLE
[ENH] enable the transfer of build infrastructure into `_build/myst` for buildable output

### DIFF
--- a/sphinxcontrib/rst2myst/builders/myst.py
+++ b/sphinxcontrib/rst2myst/builders/myst.py
@@ -93,10 +93,12 @@ class MystBuilder(Builder):
                 outf.write(line)
     
     def copy_static_files(self):
-        ensuredir(path.join(self.outdir, '_static'))
-        for static_path in self.config["jupyter_static_file_path"]:
-            entry = path.join(self.confdir, static_path)
-            copy_asset(entry, path.join(self.outdir, "_static"))
+        if "jupyter_static_file_path" in self.config:
+            for static_path in self.config["jupyter_static_file_path"]:
+                output_path = path.join(self.outdir, static_path)
+                ensuredir(output_path)
+                entry = path.join(self.confdir, static_path)
+                copy_asset(entry, output_path)
 
     def finish(self):
         self.finish_tasks.add_task(self.copy_static_files)

--- a/sphinxcontrib/rst2myst/writers/accumulators.py
+++ b/sphinxcontrib/rst2myst/writers/accumulators.py
@@ -100,8 +100,9 @@ class List:
         self.list_item = []
 
     def addto_list_item(self, content):
-        if self.list_item:
-            self.list_item.append(content)
+        if self.list_item is None:
+            self.start_list_item()
+        self.list_item.append(content)
 
     def add_list_item(self):
         content = "".join(self.list_item)

--- a/sphinxcontrib/rst2myst/writers/accumulators.py
+++ b/sphinxcontrib/rst2myst/writers/accumulators.py
@@ -100,7 +100,8 @@ class List:
         self.list_item = []
 
     def addto_list_item(self, content):
-        self.list_item.append(content)
+        if self.list_item:
+            self.list_item.append(content)
 
     def add_list_item(self):
         content = "".join(self.list_item)


### PR DESCRIPTION
PR implements : 

- [x] copy conf.py to _build/myst
- [x] copy Makefile to _build/myst
- [x] update conf.py to include myst_parser

The update of `conf.py` is done using a simple string check for keywords. 
But I was hoping I would be able to load the file as a pickle or a module and add `myst_parser` to the `extensions` object directly. But the file is throwing error on pickling. And module editing is not working.

- [x]  mimic the source in the build directory

fixes https://github.com/mmcky/sphinxcontrib-rst2myst/issues/27 
